### PR TITLE
Specify version of Werkzeug

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,3 +7,4 @@ numpy==1.22.3
 segments==2.2.1
 tabulate==0.8.9
 gunicorn==20.1.0
+Werkzeug==2.2.2


### PR DESCRIPTION
Flask is poorly defining its requirements, and somehow uses a '>=2.2.0' for the version of Werkzeug, without upper bound; inevitably, a major release of Werkzeug was made (3.0.0) and this breaks Flask; the solution is for us (and everyone using Flask, really...) to pin Werkzeug's version.